### PR TITLE
Add hint on installing missing rsync dependency first

### DIFF
--- a/repo/README.md
+++ b/repo/README.md
@@ -14,6 +14,7 @@ It will take the given path and push that entire subtree to the server (or vice-
 For [Homebrew](http://brew.sh) users it's available via the [adobe-marketing-cloud/brews tap](https://github.com/Adobe-Marketing-Cloud/homebrew-brews):
 ```
 brew tap adobe-marketing-cloud/brews
+brew install homebrew/dupes/rsync
 brew install adobe-marketing-cloud/brews/repo
 ```
 


### PR DESCRIPTION
I got this error during installation. The error message might be confusing. It's not entirely clear what to install first.

```
$ brew install adobe-marketing-cloud/brews/repo
==> Installing repo from adobe-marketing-cloud/homebrew-brews
Error: No available formula with the name "rsync" (dependency of adobe-marketing-cloud/brews/repo)
==> Searching for similarly named formulae...
These similarly named formulae were found:
grsync                                                                                                                    librsync                                                                                                                  vdirsyncer
To install one of them, run (for example):
  brew install grsync
==> Searching taps...
These formulae were found in taps:
homebrew/dupes/rsync                                                                       Caskroom/cask/arrsync                                                                      Caskroom/cask/comicbookloversync                                                           Caskroom/cask/supersync
To install one of them, run (for example):
  brew install homebrew/dupes/rsync
```